### PR TITLE
Fix last world clock is a function

### DIFF
--- a/calendar@simonwiles.net/applet.js
+++ b/calendar@simonwiles.net/applet.js
@@ -104,7 +104,11 @@ MyApplet.prototype = {
                 this._worldclocks = [];
                 this._worldclock_labels = [];
                 var i;
-                for (i in this.worldclocks) { this._worldclocks[i] = this.worldclocks[i].split("|"); }
+                for (i in this.worldclocks) { 
+                    if (typeof(this.worldclocks[i]) == 'string') {
+                        this._worldclocks[i] = this.worldclocks[i].split("|");
+                    }
+                }
                 for (i in this._worldclocks) {
                     this._worldclocks[i][1] = GLib.TimeZone.new(this._worldclocks[i][1]);
 


### PR DESCRIPTION
Hi there,

FIrst of all thanks for your cinnamon applets, it's very useful for me!

Since last Cinnamon update (3.2.x), your applet didn't work any more. I had this issue:

```
error t=2016-11-10T16:53:23.569Z this.worldclocks[i].split is not a function
trace t=2016-11-10T16:53:23.569Z 
<----------------
MyApplet.prototype._init/addWorldClocks<@/home/user/.local/share/cinnamon/applets/calendar@simonwiles.net/applet.js:109
```

After looking at the code, I found that there's an element added at the end of the wordclocks array and that element is a function. I don't know where it come from, neither what changed in the Cinnamon applet configuration variables.

Anyway, this patch fix the issue and make the clock works again. but may be there's maybe something more to change in the code.